### PR TITLE
Remove cleanup of nonexistent 'expanded' dir

### DIFF
--- a/NoMAD/NoMAD.munki.recipe
+++ b/NoMAD/NoMAD.munki.recipe
@@ -140,7 +140,6 @@
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/unpack</string>
-                    <string>%RECIPE_CACHE_DIR%/expanded</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
First time using this recipe, but I think the `expanded` dir doesn't exist anymore. I was getting an error in this final `PathDeleter` step, even though the previous steps were otherwise successful.

Thanks Tom!