### PR TITLE
Fix empty Installs dictionary

### DIFF
--- a/NoMAD/NoMAD.munki.recipe
+++ b/NoMAD/NoMAD.munki.recipe
@@ -89,17 +89,6 @@
 			<key>Processor</key>
 			<string>PkgCopier</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/payload</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-		</dict>
         <dict>
             <key>Arguments</key>
             <dict>
@@ -108,7 +97,7 @@
                     <string>/Applications/NoMAD.app</string>
                 </array>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/root</string>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
             </dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
@@ -140,6 +129,7 @@
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/unpack</string>
+		    <string>%RECIPE_CACHE_DIR%/payload</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
The _MunkiInstallsItemsCreator_ processor is currently looking to the directory that contains the contents of the _FlatPkgUnpacker_ processor rather than the NoMAD application, which was unpacked to `%RECIPE_CACHE_DIR%/payload`.