### PR TITLE
Remove Versioner and PkgCopier

### DIFF
--- a/NoMAD/NoMAD.munki.recipe
+++ b/NoMAD/NoMAD.munki.recipe
@@ -1,139 +1,114 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-    <key>Description</key>
-    <string>Imports NoMAD into Munki</string>
-    
-    <key>Identifier</key>
-    <string>com.github.tbridge.munki.nomad</string>
-    
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>NoMAD</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/NoMAD</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>testing</string>
-            </array>
-            <key>description</key>
-            <string>NoMAD is a helpful replacement for Active Directory bindings, using Kerberos and other resources to provide Active Directory services without a fragile binding plugin</string>
-            <key>display_name</key>
-            <string>NoMAD</string>
-            <key>name</key>
-            <string>%NAME%</string>
-            <key>unattended_install</key>
-            <false/>
-        </dict>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.4.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.tbridge.download.NoMAD</string>
-    <key>Process</key>
-        <array>
-            <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
-			</dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-		</dict>
+	<dict>
+		<key>Description</key>
+		<string>Imports NoMAD into Munki</string>
+		<key>Identifier</key>
+		<string>com.github.tbridge.munki.nomad</string>
+		<key>Input</key>
 		<dict>
-			<key>Arguments</key>
+			<key>NAME</key>
+			<string>NoMAD</string>
+			<key>MUNKI_REPO_SUBDIR</key>
+			<string>apps/NoMAD</string>
+			<key>pkginfo</key>
 			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/NoMAD-*.pkg/Payload</string>
+				<key>catalogs</key>
+				<array>
+					<string>testing</string>
+				</array>
+				<key>description</key>
+				<string>NoMAD is a helpful replacement for Active Directory bindings, using Kerberos and other resources to provide Active Directory services without a fragile binding plugin</string>
+				<key>display_name</key>
+				<string>NoMAD</string>
+				<key>name</key>
+				<string>%NAME%</string>
+				<key>unattended_install</key>
+				<false/>
 			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
+		<key>MinimumVersion</key>
+		<string>0.4.0</string>
+		<key>ParentRecipe</key>
+		<string>com.github.tbridge.download.NoMAD</string>
+		<key>Process</key>
+		<array>
 			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-				<key>pkg_payload_path</key>
-				<string>%found_filename%</string>
+				<key>Arguments</key>
+				<dict>
+					<key>destination_path</key>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+					<key>flat_pkg_path</key>
+					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				</dict>
+				<key>Processor</key>
+				<string>FlatPkgUnpacker</string>
 			</dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Applications/%NAME%.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pattern</key>
+					<string>%RECIPE_CACHE_DIR%/unpack/NoMAD-*.pkg/Payload</string>
+				</dict>
+				<key>Processor</key>
+				<string>FileFinder</string>
 			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>source_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+				<key>Arguments</key>
+				<dict>
+					<key>destination_path</key>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+					<key>pkg_payload_path</key>
+					<string>%found_filename%</string>
+				</dict>
+				<key>Processor</key>
+				<string>PkgPayloadUnpacker</string>
 			</dict>
-			<key>Processor</key>
-			<string>PkgCopier</string>
-		</dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/NoMAD.app</string>
-                </array>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict/>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pathname%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Clean up after ourselves</string>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-		    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-        </dict>
-
-    </array>
-</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>installs_item_paths</key>
+					<array>
+						<string>/Applications/NoMAD.app</string>
+					</array>
+					<key>faux_root</key>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+				</dict>
+				<key>Processor</key>
+				<string>MunkiInstallsItemsCreator</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>MunkiPkginfoMerger</string>
+				<key>Arguments</key>
+				<dict/>
+			</dict>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_path</key>
+					<string>%pathname%</string>
+					<key>repo_subdirectory</key>
+					<string>%MUNKI_REPO_SUBDIR%</string>
+				</dict>
+				<key>Processor</key>
+				<string>MunkiImporter</string>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Clean up after ourselves</string>
+				<key>Processor</key>
+				<string>PathDeleter</string>
+				<key>Arguments</key>
+				<dict>
+					<key>path_list</key>
+					<array>
+						<string>%RECIPE_CACHE_DIR%/unpack</string>
+						<string>%RECIPE_CACHE_DIR%/payload</string>
+					</array>
+				</dict>
+			</dict>
+		</array>
+	</dict>
 </plist>


### PR DESCRIPTION
The _Versioner_ and _PkgCopier_ processes are both unnecessary as their function is replicated in _MunkiImporter_. Also, the presence of PkgCopier results in an addition to the recipe's summary output on each run.

(N.B. I've adjusted some of the indentation, hence the extent of the changes.)