### PR TITLE
Remove PkgCopier

### DIFF
--- a/NoMAD/NoMAD.munki.recipe
+++ b/NoMAD/NoMAD.munki.recipe
@@ -78,17 +78,6 @@
 			<key>Processor</key>
 			<string>Versioner</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>source_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCopier</string>
-		</dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
PkgCopier will leave a notification in AutoPkg(r) even if no change is detected.

The following packages were copied: /Users/$USER/Library/AutoPkg/Cache/local.munki.NoMAD/NoMAD-1.1.3.886.pkg
