### PR TITLE
NoMAD

### DIFF
--- a/NoMAD/NoMAD.download.recipe
+++ b/NoMAD/NoMAD.download.recipe
@@ -4,46 +4,73 @@
 <dict>
     <key>Description</key>
     <string>Downloads NoMAD</string>
-    
     <key>Identifier</key>
     <string>com.github.tbridge.download.NoMAD</string>
-    
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>NoMAD</string>
     </dict>
-    <key>MinimumVersion</key>
-    <string>0.4.0</string>
+     <key>MinimumVersion</key>
+    <string>1.0.0</string>
     <key>Process</key>
     <array>
-    	<dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
+        <dict>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://files.nomad.menu/NoMAD.pkg</string>
+                <key>github_repo</key>
+                <string>jamf/NoMAD</string>
             </dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
         <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
             <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%</string>
-                <key>expected_authority_names</key>
-                <array>
-                	<string>Developer ID Installer: Orchard &amp; Grove Inc. (VRPY9KHGX6)</string>
-                	<string>Developer ID Certification Authority</string>
-            		<string>Apple Root CA</string>
-            	</array>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/NoMAD.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.trusourcelabs.NoMAD" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = AAPZK3CB24)</string>
             </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/NoMAD.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
         </dict>
     </array>
 </dict>

--- a/NoMAD/NoMAD.munki.recipe
+++ b/NoMAD/NoMAD.munki.recipe
@@ -4,10 +4,8 @@
 <dict>
     <key>Description</key>
     <string>Imports NoMAD into Munki</string>
-    
     <key>Identifier</key>
     <string>com.github.tbridge.munki.nomad</string>
-    
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -31,98 +29,33 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0.0</string>
     <key>ParentRecipe</key>
     <string>com.github.tbridge.download.NoMAD</string>
     <key>Process</key>
-        <array>
-            <dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
-			</dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/NoMAD-*.pkg/Payload</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-				<key>pkg_payload_path</key>
-				<string>%found_filename%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Applications/NoMAD.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
+         <array>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/NoMAD.app</string>
-                </array>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
             </dict>
             <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict/>
+            <string>DmgCreator</string>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Clean up after ourselves</string>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-		    <string>%RECIPE_CACHE_DIR%/payload</string>
-                </array>
-            </dict>
-        </dict>
-
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi, @tbridge 

This PR moves the NoMAD download recipe to use the new Github repo where all future releases will come from. The Munki recipe has also been updated to reflect the download changes. 

Thanks! 
Paul

```
autopkg run -vv /Users/paul/Documents/GitHub/tbridge-recipes/NoMAD/NoMAD.munki.recipe 
Processing /Users/paul/Documents/GitHub/tbridge-recipes/NoMAD/NoMAD.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/tbridge-recipes/NoMAD/NoMAD.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'jamf/NoMAD'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'NoMAD-1.3.0.RC1.zip' from release '1.3.0'
{'Output': {'asset_url': 'https://api.github.com/repos/jamf/NoMAD/releases/assets/53714911',
            'release_notes': 'Universal build.',
            'url': 'https://github.com/jamf/NoMAD/releases/download/1.3.0/NoMAD-1.3.0.RC1.zip',
            'version': '1.3.0'}}
URLDownloader
{'Input': {'filename': 'NoMAD-1.3.0.zip',
           'url': 'https://github.com/jamf/NoMAD/releases/download/1.3.0/NoMAD-1.3.0.RC1.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 12 Jan 2022 09:52:18 GMT
URLDownloader: Storing new ETag header: "0x8D9D5B138D0D41E"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip
{'Output': {'download_changed': True,
            'etag': '"0x8D9D5B138D0D41E"',
            'last_modified': 'Wed, 12 Jan 2022 09:52:18 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip',
           'destination_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename NoMAD-1.3.0.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip to /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.trusourcelabs.NoMAD" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = AAPZK3CB24)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 1.3.0 in file /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD/NoMAD.app/Contents/Info.plist
{'Output': {'version': '1.3.0'}}
DmgCreator
{'Input': {'dmg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD.dmg',
           'dmg_root': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD'}}
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD at /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/NoMAD.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'NoMAD is a helpful replacement for '
                                      'Active Directory bindings, using '
                                      'Kerberos and other resources to provide '
                                      'Active Directory services without a '
                                      'fragile binding plugin',
                       'display_name': 'NoMAD',
                       'name': 'NoMAD',
                       'unattended_install': False},
           'repo_subdirectory': 'apps/NoMAD'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/NoMAD/NoMAD-1.3.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/NoMAD/NoMAD-1.3.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'NoMAD',
                                                       'pkg_repo_path': 'apps/NoMAD/NoMAD-1.3.0.dmg',
                                                       'pkginfo_path': 'apps/NoMAD/NoMAD-1.3.0.plist',
                                                       'version': '1.3.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2022, 6, 29, 15, 13, 53),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.4'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'NoMAD is a helpful replacement for '
                                          'Active Directory bindings, using '
                                          'Kerberos and other resources to '
                                          'provide Active Directory services '
                                          'without a fragile binding plugin',
                           'display_name': 'NoMAD',
                           'installer_item_hash': '144a6977d5b562d7fd15d599b20a975e444cbb8b5c0969325f1776b1cf4dce05',
                           'installer_item_location': 'apps/NoMAD/NoMAD-1.3.0.dmg',
                           'installer_item_size': 8916,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.trusourcelabs.NoMAD',
                                         'CFBundleName': 'NoMAD',
                                         'CFBundleShortVersionString': '1.3.0',
                                         'CFBundleVersion': '1053',
                                         'minosversion': '10.10',
                                         'path': '/Applications/NoMAD.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'NoMAD.app'}],
                           'minimum_os_version': '10.10',
                           'name': 'NoMAD',
                           'unattended_install': False,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '1.3.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/NoMAD/NoMAD-1.3.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/NoMAD/NoMAD-1.3.0.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/receipts/NoMAD.munki-receipt-20220629-161353.plist

The following new items were downloaded:
    Download Path                                                                               
    -------------                                                                               
    /Users/paul/Library/AutoPkg/Cache/com.github.tbridge.munki.nomad/downloads/NoMAD-1.3.0.zip  

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                  Pkg Repo Path               Icon Repo Path  
    ----   -------  --------  ------------                  -------------               --------------  
    NoMAD  1.3.0    testing   apps/NoMAD/NoMAD-1.3.0.plist  apps/NoMAD/NoMAD-1.3.0.dmg 
```