### PR TITLE
Deprecate Azendoo recipes

### DIFF
--- a/Azendoo/Azendoo.download.recipe
+++ b/Azendoo/Azendoo.download.recipe
@@ -16,9 +16,18 @@
 		<string>Azendoo</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Azendoo is no longer available outside of the Mac App Store. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the non-functional Azendoo recipes, since that software is now only available from the Mac App Store.
