### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Kerio Control VPN/KerioControlVPN.download.recipe
+++ b/Kerio Control VPN/KerioControlVPN.download.recipe
@@ -24,7 +24,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                             <string>http://download.kerio.com/dwn/kerio-control-vpnclient-mac.dmg</string>
+                             <string>https://download.kerio.com/dwn/kerio-control-vpnclient-mac.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._